### PR TITLE
fix: handle github provider not supporting listing

### DIFF
--- a/src/lib/providers/cache/index.ts
+++ b/src/lib/providers/cache/index.ts
@@ -70,12 +70,10 @@ export async function getCache(
 }
 
 export async function deleteCache(): Promise<void> {
-  core.error(`Cannot delete github cache automatically.`)
   throw new Error(`Cannot delete github cache automatically.`)
 }
 
 export async function listCache(): Promise<TListFile[]> {
-  core.error(`Cannot list github cache automatically.`)
   throw new Error(`Cannot list github cache automatically.`)
 }
 

--- a/src/lib/server/cleanup.ts
+++ b/src/lib/server/cleanup.ts
@@ -47,7 +47,16 @@ export async function cleanup(
 
   const provider = getProvider(tracker)
 
-  const files = await provider.list()
+  let files;
+  try {
+    files = await provider.list()
+  } catch (e) {
+    const msg = `Provider does not support listing: ${(e as Error).message}
+Exiting early, no files were cleaned up.`
+    ctx.log.info(msg)
+    return
+  }
+
 
   const fileToDelete: (TListFile & {
     reason: 'max-age' | 'max-files' | 'max-size'


### PR DESCRIPTION
Thanks for this project, it has fixed our "infinitely growing and perpetually invalidating" pains from the result of following Vercel's guide on how to use turbo with gh actions.

## Change described
Instead reporting an error and throwing one, made it so that listing only throws an error, which can be handled anyhow later on. In cleanup, will handle it by writing an info log and exiting from clean up early. This was done to mitigate the errors reported from github, every time the cleanup would run and the code would reach the changed lines, which happened (in my case) when "max-age" was specified for the inputs.

This just removes the unhelpful error msg from being reported by github, but it does not address the problem of not being able to do the clean up.  Either listing needs to be implemented for the gh provider, or stated in the readme that cleanup actually doesn't work with gh (yet?).

Also note that I'm not familiar with the project,  I've just read the 2 files I've changed, haven't tried to set up the environment or anything, so feel free to treat the changes as a draft.