### PR TITLE
Update action runtime from node20 to node22

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -64,6 +64,6 @@ inputs:
     required: false
     default: '41230'
 runs:
-  using: node20
+  using: node22
   main: dist/setup/index.js
   post: dist/post/index.js


### PR DESCRIPTION
## Summary
- Updates `action.yml` runtime from `node20` to `node22` to eliminate the Node.js 20 deprecation warning for all consumers
- GitHub Actions will force Node 24 starting June 2, 2026; `node22` is the current supported runtime target

Closes #829

## Test plan
- [ ] Verify CI passes on the PR
- [ ] Confirm the deprecation warning no longer appears when using the action

🤖 Generated with [Claude Code](https://claude.com/claude-code)