### PR TITLE
Update README to remove Vercel cache pricing mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ The main technical difference lies in how caching is handled:
 **Vercel's Approach**
 
 - Uses a remote caching server hosted by Vercel
-- Become expensive for large monorepos with multiple apps/packages
-- May have limitations based on your Vercel plan
 
 **This Action's Approach**
 


### PR DESCRIPTION
Vercel Remote Cache is free to use. Additionally, the only limits are [Fair Use guidelines](https://vercel.com/docs/monorepos/remote-caching#usage).