### PR TITLE
fix: sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,12 +50,12 @@ jobs:
           # merge in main, taking main's version on all conflicts
           git merge origin/$SOURCE --strategy=recursive -X theirs --no-edit
 
-          # now override package.json with main's copy
+          # now override package.json with main's copy (if it differs after merge)
           git checkout origin/$SOURCE -- package.json
           git add package.json
-
-          # commit that one-file change
-          git commit -m "chore(sync): restore package.json from $SOURCE"
+          if ! git diff --cached --quiet; then
+            git commit -m "chore(sync): restore package.json from $SOURCE"
+          fi
 
           # push the updated branch (history + tags intact)
           git push origin $TARGET


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> CI-only change to sync commit behavior; no application runtime or release artifact logic is modified beyond avoiding no-op commits.
> 
> **Overview**
> Updates the **Sync** job in `release.yml` so it no longer always creates a commit after resetting `package.json` from the source branch.
> 
> After merging and checking out `package.json` from `SOURCE`, the workflow now runs **`git diff --cached --quiet`** and only commits with `chore(sync): restore package.json from $SOURCE` when the index actually changed. That avoids empty or redundant commits when the file already matches post-merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58cf3adf52c6b413639e34f266e7e70367e70606. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->